### PR TITLE
Hotfix/validate preview token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#5](https://github.com/netglue/prismic-php-kit/pull/4) ensures that the preview token is validated before any attempt
+is made to retrieve a ref from the api.
 
 ## 4.2.0 - 2018-11-15
 

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -377,7 +377,7 @@ class Api
          * causes the problem.
          */
         $previewHost = str_replace('.cdn.', '.', strtolower($previewHost));
-        $apiHost = str_replace('.cdn.', '.', strtolower($previewHost));
+        $apiHost = str_replace('.cdn.', '.', strtolower($apiHost));
         if ($previewHost !== $apiHost) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'The host "%s" does not match the api host "%s"',

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -23,6 +23,7 @@ use function parse_url;
 use function preg_match;
 use function sprintf;
 use function str_replace;
+use function strtolower;
 use const FILTER_FLAG_PATH_REQUIRED;
 use const FILTER_VALIDATE_URL;
 
@@ -368,6 +369,15 @@ class Api
         }
         ['host' => $previewHost] = parse_url($token);
         ['host' => $apiHost] = parse_url($this->url);
+        /**
+         * Because the API host will possibly be name.cdn.prismic.io but the preview domain can be name.prismic.io
+         * we can only reliably verify the same parent domain name if we parse both domains with something that uses
+         * the public suffix list, like https://github.com/jeremykendall/php-domain-parser for example. We really
+         * don't want to have to go through all that, so for now we will just strip/hard-code the 'cdn' part which
+         * causes the problem.
+         */
+        $previewHost = str_replace('.cdn.', '.', strtolower($previewHost));
+        $apiHost = str_replace('.cdn.', '.', strtolower($previewHost));
         if ($previewHost !== $apiHost) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'The host "%s" does not match the api host "%s"',

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -16,11 +16,15 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use function array_filter;
 use function count;
+use function filter_var;
 use function json_decode;
 use function md5;
+use function parse_url;
 use function preg_match;
 use function sprintf;
 use function str_replace;
+use const FILTER_FLAG_PATH_REQUIRED;
+use const FILTER_VALIDATE_URL;
 
 /**
  * This class embodies a connection to your prismic.io repository's API.
@@ -347,6 +351,33 @@ class Api
     }
 
     /**
+     * Validate and filter a preview token ensuring that the URL it represents corresponds to the same host as the API
+     * @param string $token
+     * @return string The validated token
+     */
+    private function validatePreviewToken(string $token) : string
+    {
+        // Even if the token has already been decoded, if it's a reasonable url,
+        // repeated decodes should not cause a problem.
+        $token = urldecode($token);
+        if (! filter_var($token, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'The preview token "%s" is not a valid url',
+                $token
+            ), 400);
+        }
+        ['host' => $previewHost] = parse_url($token);
+        ['host' => $apiHost] = parse_url($this->url);
+        if ($previewHost !== $apiHost) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'The host "%s" is not valid for a preview url',
+                $previewHost
+            ), 400);
+        }
+        return $token;
+    }
+
+    /**
      * Return the URL to display a given preview
      * @param string $token as received from Prismic server to identify the content to preview
      * @param string $defaultUrl the URL to return if the preview doesn't correspond to a document
@@ -356,7 +387,21 @@ class Api
     public function previewSession(string $token, string $defaultUrl) : string
     {
         try {
+            // $token is untrusted input, possibly from a GET request and will be retrieved by the http client
+            $token = $this->validatePreviewToken($token);
             $response = $this->httpClient->request('GET', $token);
+            $responseBody = json_decode((string) $response->getBody());
+            if (isset($responseBody->mainDocument)) {
+                $document = $this->getById(
+                    $responseBody->mainDocument,
+                    ['ref' => $token]
+                );
+                if ($document && $this->linkResolver) {
+                    $url = $this->linkResolver->resolve($document->asLink());
+                    return $url ? $url : $defaultUrl;
+                }
+            }
+            return $defaultUrl;
         } catch (RequestException $requestException) {
             $apiResponse = $requestException->getResponse();
             if ($apiResponse && Exception\ExpiredPreviewTokenException::isTokenExpiryResponse($apiResponse)) {
@@ -366,18 +411,6 @@ class Api
         } catch (GuzzleException $exception) {
             throw Exception\RequestFailureException::fromGuzzleException($exception);
         }
-        $responseBody = json_decode((string) $response->getBody());
-        if (isset($responseBody->mainDocument)) {
-            $document = $this->getById(
-                $responseBody->mainDocument,
-                ['ref' => $token]
-            );
-            if ($document && $this->linkResolver) {
-                $url = $this->linkResolver->resolve($document->asLink());
-                return $url ? $url : $defaultUrl;
-            }
-        }
-        return $defaultUrl;
     }
 
     /**

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -370,8 +370,9 @@ class Api
         ['host' => $apiHost] = parse_url($this->url);
         if ($previewHost !== $apiHost) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'The host "%s" is not valid for a preview url',
-                $previewHost
+                'The host "%s" does not match the api host "%s"',
+                $previewHost,
+                $apiHost
             ), 400);
         }
         return $token;

--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace Prismic;
 
-use function gettype;
 use GuzzleHttp\Exception\GuzzleException;
-use function is_object;
 use Prismic\Exception;
 use Psr\Cache\CacheException;
 use Psr\Cache\CacheItemInterface;
+use stdClass;
 use function array_map;
 use function current;
+use function gettype;
 use function http_build_query;
 use function implode;
 use function is_array;
@@ -374,7 +374,7 @@ class SearchForm
             if ($json === null) {
                 throw new Exception\RuntimeException('Unable to decode json response');
             }
-            if (! is_object($json)) {
+            if (! $json instanceof stdClass) {
                 throw new Exception\UnexpectedValueException(sprintf(
                     'Expected the response from the API to be decoded as an object but %s returned',
                     gettype($json)

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -386,7 +386,7 @@ class ApiTest extends TestCase
         $token = urlencode($url);
         $this->httpClient->request('GET', $url)->shouldNotBeCalled();
         $this->expectException(Prismic\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The host "en-gb.wordpress.org" is not valid for a preview url');
+        $this->expectExceptionMessage('The host "en-gb.wordpress.org" does not match the api host "whatever.prismic.io"');
         $api = $this->getApiWithDefaultData();
         $api->previewSession($token, '/');
     }

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -5,7 +5,6 @@ namespace Prismic\Test;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use Prismic;
@@ -18,6 +17,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use function json_decode;
 
 class ApiTest extends TestCase
 {
@@ -36,6 +36,9 @@ class ApiTest extends TestCase
      */
     private $expectedMasterRef = 'UgjWQN_mqa8HvPJY';
 
+    /** @var string */
+    private $repoUrl = 'https://whatever.prismic.io/api/v2';
+
     public function setUp()
     {
         unset($_COOKIE);
@@ -48,7 +51,7 @@ class ApiTest extends TestCase
     protected function getApi() : Api
     {
         return Api::get(
-            'https://whatever.prismic.io/api/v2',
+            $this->repoUrl,
             'My-Access-Token',
             $this->httpClient->reveal(),
             $this->cache->reveal()
@@ -57,8 +60,9 @@ class ApiTest extends TestCase
 
     protected function getApiWithDefaultData() : Api
     {
-        $url = 'https://whatever.prismic.io/api/v2?access_token=My-Access-Token';
+        $url = $this->repoUrl . '?access_token=My-Access-Token';
         $key = Api::generateCacheKey($url);
+        /** @var CacheItemInterface|ObjectProphecy $item */
         $item = $this->prophesize(CacheItemInterface::class);
         $item->get()->willReturn($this->apiData);
         $item->isHit()->willReturn(true);
@@ -68,9 +72,9 @@ class ApiTest extends TestCase
         return $this->getApi();
     }
 
-    public function testQueryStringOnApiUrlIsNotDestroyed()
+    public function testQueryStringOnApiUrlIsNotDestroyed() : void
     {
-        $url = 'https://repo.prismic.io/api/v2?someParam=someValue&foo=bar';
+        $url = $this->repoUrl . '?someParam=someValue&foo=bar';
         $token = 'My-Access-Token';
         $expect = $url . '&access_token=' . $token;
         $expectedKey = Api::generateCacheKey($expect);
@@ -86,8 +90,9 @@ class ApiTest extends TestCase
         $this->assertInstanceOf(Api::class, $api);
     }
 
-    public function testApiVersionInformation()
+    public function testApiVersionInformation() : void
     {
+        /** @var CacheItemInterface|ObjectProphecy $item */
         $item = $this->prophesize(CacheItemInterface::class);
         $item->get()->willReturn($this->apiData);
         $item->isHit()->willReturn(true);
@@ -112,16 +117,17 @@ class ApiTest extends TestCase
         $this->assertSame('2.0.0', $api->getApiVersion());
     }
 
-    public function testCachedApiDataWillBeUsedIfAvailable()
+    public function testCachedApiDataWillBeUsedIfAvailable() : void
     {
         $api = $this->getApiWithDefaultData();
         $this->assertSame(serialize($this->apiData), serialize($api->getData()));
     }
 
-    public function testGetIsCalledOnHttpClientWhenTheCacheIsEmpty()
+    public function testGetIsCalledOnHttpClientWhenTheCacheIsEmpty() : void
     {
-        $url = 'https://whatever.prismic.io/api/v2?access_token=My-Access-Token';
+        $url = $this->repoUrl . '?access_token=My-Access-Token';
         $key = Api::generateCacheKey($url);
+        /** @var CacheItemInterface|ObjectProphecy $item */
         $item = $this->prophesize(CacheItemInterface::class);
         $item->isHit()->willReturn(false);
         $item->set(Argument::any())->shouldBeCalled();
@@ -131,15 +137,14 @@ class ApiTest extends TestCase
         $response->getBody()->willReturn($this->getJsonFixture('data.json'));
         $this->httpClient->request('GET', $url)->willReturn($response->reveal());
 
-
         $api = $this->getApi();
         $this->assertInstanceOf(ClientInterface::class, $api->getHttpClient());
         $this->assertSame(serialize($this->apiData), serialize($api->getData()));
     }
 
-    public function testApiDataCanBeForcefullyReloaded()
+    public function testApiDataCanBeForcefullyReloaded() : void
     {
-        $url = 'https://whatever.prismic.io/api/v2?access_token=My-Access-Token';
+        $url = $this->repoUrl . '?access_token=My-Access-Token';
         $key = Api::generateCacheKey($url);
         $item = $this->prophesize(CacheItemInterface::class);
         $item->isHit()->willReturn(false);
@@ -157,13 +162,13 @@ class ApiTest extends TestCase
         $this->assertNotSame($data, $api->getData());
     }
 
-    public function testMasterRefIsReturnedWhenNeitherPreviewOrExperimentsAreActive()
+    public function testMasterRefIsReturnedWhenNeitherPreviewOrExperimentsAreActive() : void
     {
         $api = $this->getApiWithDefaultData();
         $this->assertSame($this->expectedMasterRef, $api->ref());
     }
 
-    public function testMasterRefIsReturnedByMasterMethod()
+    public function testMasterRefIsReturnedByMasterMethod() : void
     {
         $api = $this->getApiWithDefaultData();
         $ref = $api->master();
@@ -171,14 +176,14 @@ class ApiTest extends TestCase
         $this->assertSame($this->expectedMasterRef, (string) $ref);
     }
 
-    public function testInPreviewAndInExperimentIsFalseWhenNoCookiesAreSet()
+    public function testInPreviewAndInExperimentIsFalseWhenNoCookiesAreSet() : void
     {
         $api = $this->getApiWithDefaultData();
         $this->assertFalse($api->inPreview());
         $this->assertFalse($api->inExperiment());
     }
 
-    public function getPreviewRefs()
+    public function getPreviewRefs() : array
     {
         return [
             [
@@ -206,8 +211,10 @@ class ApiTest extends TestCase
 
     /**
      * @dataProvider getPreviewRefs
+     * @param array $cookie
+     * @param string $expect
      */
-    public function testPreviewRefIsReturnedWhenPresentInSuperGlobal(array $cookie, string $expect)
+    public function testPreviewRefIsReturnedWhenPresentInSuperGlobal(array $cookie, string $expect) : void
     {
         $_COOKIE = $cookie;
         $api = $this->getApiWithDefaultData();
@@ -216,18 +223,20 @@ class ApiTest extends TestCase
 
     /**
      * @dataProvider getPreviewRefs
+     * @param array $cookie
+     * @param string $expect
      */
-    public function testCookieValuesCanBeSetOverridingSuperGlobal(array $cookie, string $expect)
+    public function testCookieValuesCanBeSetOverridingSuperGlobal(array $cookie, string $expect) : void
     {
         $_COOKIE = [
-            'io.prismic.preview' => uniqid(),
+            'io.prismic.preview' => uniqid('', true),
         ];
         $api = $this->getApiWithDefaultData();
         $api->setRequestCookies($cookie);
         $this->assertSame($expect, $api->ref());
     }
 
-    public function testInPreviewIsTrueWhenPreviewCookieIsSet()
+    public function testInPreviewIsTrueWhenPreviewCookieIsSet() : void
     {
         $_COOKIE = [
             'io.prismic.preview' => 'whatever',
@@ -236,7 +245,7 @@ class ApiTest extends TestCase
         $this->assertTrue($api->inPreview());
     }
 
-    public function testRefDoesNotReturnStaleExperimentRef()
+    public function testRefDoesNotReturnStaleExperimentRef() : void
     {
         $_COOKIE = [
             'io.prismic.experiment' => 'Stale Experiment Cookie Value',
@@ -245,7 +254,7 @@ class ApiTest extends TestCase
         $this->assertSame($this->expectedMasterRef, $api->ref());
     }
 
-    public function testCorrectExperimentRefIsReturnedWhenCookieIsSet()
+    public function testCorrectExperimentRefIsReturnedWhenCookieIsSet() : void
     {
         $runningGoogleCookie = '_UQtin7EQAOH5M34RQq6Dg 1';
         $expectedRef = 'VDUUmHIKAZQKk9uq'; // The ref at index 1 for the variations in this experiment
@@ -260,7 +269,7 @@ class ApiTest extends TestCase
     /**
      * @depends testCorrectExperimentRefIsReturnedWhenCookieIsSet
      */
-    public function testPreviewRefTrumpsExperimentRefWhenSet()
+    public function testPreviewRefTrumpsExperimentRefWhenSet() : void
     {
         $runningGoogleCookie = '_UQtin7EQAOH5M34RQq6Dg 1';
         $_COOKIE = [
@@ -272,14 +281,14 @@ class ApiTest extends TestCase
         $this->assertFalse($api->inExperiment());
     }
 
-    public function testBookmarkReturnsCorrectDocumentId()
+    public function testBookmarkReturnsCorrectDocumentId() : void
     {
         $api = $this->getApiWithDefaultData();
         $this->assertSame('Ue0EDd_mqb8Dhk3j', $api->bookmark('about'));
         $this->assertNull($api->bookmark('unknown-bookmark'));
     }
 
-    public function testFormsReturnsOnlyFormInstances()
+    public function testFormsReturnsOnlyFormInstances() : void
     {
         $api = $this->getApiWithDefaultData();
         $forms = $api->forms();
@@ -287,24 +296,22 @@ class ApiTest extends TestCase
         $this->assertInstanceOf(SearchForm::class, $forms->everything);
     }
 
-    public function testFormsIsASearchFormCollection()
+    public function testFormsIsASearchFormCollection() : void
     {
         $api = $this->getApiWithDefaultData();
         $forms = $api->forms();
         $this->assertInstanceOf(Prismic\SearchFormCollection::class, $forms);
     }
 
-    /**
-     * @expectedException \Prismic\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The search form named "notHere" does not exist
-     */
-    public function testExceptionThrownAccessingASearchFormThatDoesNotExist()
+    public function testExceptionThrownAccessingASearchFormThatDoesNotExist() : void
     {
+        $this->expectException(Prismic\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The search form named "notHere" does not exist');
         $api = $this->getApiWithDefaultData();
         $api->forms()->notHere;
     }
 
-    public function testRefsGroupsRefsByLabel()
+    public function testRefsGroupsRefsByLabel() : void
     {
         $api = $this->getApiWithDefaultData();
         $refs = $api->refs();
@@ -314,21 +321,21 @@ class ApiTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Prismic\Ref::class, $refs);
     }
 
-    public function testRefsContainsOnlyFirstEncounteredRefWithLabel()
+    public function testRefsContainsOnlyFirstEncounteredRefWithLabel() : void
     {
         $api = $this->getApiWithDefaultData();
         $refs = $api->refs();
         $this->assertSame('UgjWRd_mqbYHvPJa', (string) $refs['San Francisco Grand opening']);
     }
 
-    public function testGetRefFromLabelReturnsExpectedRef()
+    public function testGetRefFromLabelReturnsExpectedRef() : void
     {
         $api = $this->getApiWithDefaultData();
         $ref = $api->getRefFromLabel('San Francisco Grand opening');
         $this->assertSame('UgjWRd_mqbYHvPJa', (string) $ref);
     }
 
-    public function testUsefulExceptionIsThrownWhenApiCannotBeReached()
+    public function testUsefulExceptionIsThrownWhenApiCannotBeReached() : void
     {
         $client = new Client(['connect_timeout' => 0.01]);
         try {
@@ -341,16 +348,14 @@ class ApiTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Prismic\Exception\RequestFailureException
-     * @expectedExceptionMessage Api Request Failed
-     */
-    public function testPreviewSessionWrapsGuzzleExceptions()
+    public function testPreviewSessionWrapsGuzzleExceptions() : void
     {
         $exception = new \GuzzleHttp\Exception\TransferException('Some Exception Message');
-        $this->httpClient->request('GET', 'SomeToken')->willThrow($exception);
+        $this->httpClient->request('GET', $this->repoUrl)->willThrow($exception);
         $api = $this->getApiWithDefaultData();
-        $api->previewSession('SomeToken', '/');
+        $this->expectException(Prismic\Exception\RequestFailureException::class);
+        $this->expectExceptionMessage('Api Request Failed');
+        $api->previewSession($this->repoUrl, '/');
     }
 
     public function testExpiredPreviewTokenIsReThrownWithSpecialisedException() : void
@@ -359,46 +364,65 @@ class ApiTest extends TestCase
         $response->getBody()->write('{"error":"Preview token expired"}');
         $guzzleException = $this->prophesize(RequestException::class);
         $guzzleException->getResponse()->willReturn($response);
-        $this->httpClient->request('GET', 'SomeToken')->willThrow($guzzleException->reveal());
+        $this->httpClient->request('GET', $this->repoUrl)->willThrow($guzzleException->reveal());
         $api = $this->getApiWithDefaultData();
         $this->expectException(Prismic\Exception\ExpiredPreviewTokenException::class);
-        $api->previewSession('SomeToken', '/');
+        $api->previewSession($this->repoUrl, '/');
     }
 
-    public function testDefaultUrlIsReturnedWhenPreviewResponseDoesNotContainMainDocument()
+    public function testNonUrlLikePreviewTokenIsInvalid() : void
+    {
+        $token = 'foo';
+        $this->httpClient->request('GET', $token)->shouldNotBeCalled();
+        $this->expectException(Prismic\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The preview token "foo" is not a valid url');
+        $api = $this->getApiWithDefaultData();
+        $api->previewSession($token, '/');
+    }
+
+    public function testPreviewUrlIsInvalidForNonMatchingApiHost() : void
+    {
+        $url = 'https://en-gb.wordpress.org/wordpress-4.9.8-en_GB.zip';
+        $token = urlencode($url);
+        $this->httpClient->request('GET', $url)->shouldNotBeCalled();
+        $this->expectException(Prismic\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The host "en-gb.wordpress.org" is not valid for a preview url');
+        $api = $this->getApiWithDefaultData();
+        $api->previewSession($token, '/');
+    }
+
+    public function testDefaultUrlIsReturnedWhenPreviewResponseDoesNotContainMainDocument() : void
     {
         $response = $this->prophesize(ResponseInterface::class);
         $response->getBody()->willReturn('{}');
-        $this->httpClient->request('GET', 'SomeToken')->willReturn($response->reveal());
+        $this->httpClient->request('GET', $this->repoUrl)->willReturn($response->reveal());
         $api = $this->getApiWithDefaultData();
-        $url = $api->previewSession('SomeToken', '/TheDefaultUrl');
+        $url = $api->previewSession($this->repoUrl, '/TheDefaultUrl');
         $this->assertSame('/TheDefaultUrl', $url);
     }
 
-    public function testFirstDocumentUrlIsReturnedWhenAMainDocumentIsSet()
+    public function testFirstDocumentUrlIsReturnedWhenAMainDocumentIsSet() : void
     {
         /**
          * The Preview Response from the API
          */
         $previewResponse = $this->prophesize(ResponseInterface::class);
         $previewResponse->getBody()->willReturn($this->getJsonFixture('preview-session.json'));
-        $this->httpClient->request('GET', 'SomeToken')->willReturn($previewResponse->reveal());
+        $this->httpClient->request('GET', $this->repoUrl)->willReturn($previewResponse->reveal());
 
         /**
          * Setup the Search Response from the API
          */
-        $expectedFormUrl = 'http://repo.prismic.io/api/v2/documents/search?ref=SomeToken&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22SomeDocumentId%22%29%5D%5D&lang=%2A';
-        $formCacheKey = Api::generateCacheKey($expectedFormUrl);
-        $searchResult = \json_decode($this->getJsonFixture('search-results.json'));
+        $searchResult = json_decode($this->getJsonFixture('search-results.json'));
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()->willReturn(true);
         $cacheItem->get()->willReturn($searchResult);
-        $this->cache->getItem($formCacheKey)->willReturn($cacheItem->reveal());
+        $this->cache->getItem(Argument::type('string'))->willReturn($cacheItem->reveal());
 
 
         $api = $this->getApiWithDefaultData();
         $api->setLinkResolver(new FakeLinkResolver());
-        $url = $api->previewSession('SomeToken', '/TheDefaultUrl');
+        $url = $api->previewSession($this->repoUrl, '/TheDefaultUrl');
         $this->assertSame('RESOLVED_LINK', $url);
     }
 }


### PR DESCRIPTION
This patch ensures that a preview token used in an attempt to start a preview session is valid before the api client makes a request to get the preview ref