### PR TITLE
No data property

### DIFF
--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -286,11 +286,7 @@ class Api
     public function bookmark(string $name) :? string
     {
         $bookmarks = $this->bookmarks();
-        if (isset($bookmarks[$name])) {
-            return $bookmarks[$name];
-        }
-
-        return null;
+        return $bookmarks[$name] ?? null;
     }
 
     /**

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -387,7 +387,7 @@ class Api
                 );
                 if ($document && $this->linkResolver) {
                     $url = $this->linkResolver->resolve($document->asLink());
-                    return $url ? $url : $defaultUrl;
+                    return $url ?: $defaultUrl;
                 }
             }
             return $defaultUrl;

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -167,21 +167,6 @@ class Api
         }
     }
 
-    public function reloadApiData() : void
-    {
-        try {
-            $url = $this->apiDataUrl();
-            $key = static::generateCacheKey($url);
-            $this->cache->deleteItem($key);
-        } catch (CacheException $cacheException) {
-            throw new Exception\RuntimeException(
-                'A cache exception occurred whilst deleting cached api data',
-                0,
-                $cacheException
-            );
-        }
-    }
-
     public function getHydrator() : HydratorInterface
     {
         return $this->hydrator;

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -285,7 +285,12 @@ class ApiTest extends TestCase
     {
         $api = $this->getApiWithDefaultData();
         $this->assertSame('Ue0EDd_mqb8Dhk3j', $api->bookmark('about'));
-        $this->assertNull($api->bookmark('unknown-bookmark'));
+    }
+
+    public function testBookmarkReturnsNullForUnknownBookmark() : void
+    {
+        $api = $this->getApiWithDefaultData();
+        $this->assertNull($api->bookmark('not_known_bookmark_name'));
     }
 
     public function testFormsReturnsOnlyFormInstances() : void

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -142,26 +142,6 @@ class ApiTest extends TestCase
         $this->assertSame(serialize($this->apiData), serialize($api->getData()));
     }
 
-    public function testApiDataCanBeForcefullyReloaded() : void
-    {
-        $url = $this->repoUrl . '?access_token=My-Access-Token';
-        $key = Api::generateCacheKey($url);
-        $item = $this->prophesize(CacheItemInterface::class);
-        $item->isHit()->willReturn(false);
-        $item->set(Argument::any())->shouldBeCalledTimes(2);
-        $this->cache->getItem($key)->willReturn($item->reveal());
-        $this->cache->deleteItem($key)->shouldBeCalledTimes(1);
-        $this->cache->save($item->reveal())->shouldBeCalledTimes(2);
-        $response = $this->prophesize(ResponseInterface::class);
-        $response->getBody()->willReturn($this->getJsonFixture('data.json'));
-        $this->httpClient->request('GET', $url)->willReturn($response->reveal());
-
-        $api = $this->getApi();
-        $data = $api->getData();
-        $api->reloadApiData();
-        $this->assertNotSame($data, $api->getData());
-    }
-
     public function testMasterRefIsReturnedWhenNeitherPreviewOrExperimentsAreActive() : void
     {
         $api = $this->getApiWithDefaultData();

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -340,6 +340,7 @@ class ApiTest extends TestCase
         $client = new Client(['connect_timeout' => 0.01]);
         try {
             $api = Api::get('http://example.example', null, $client);
+            $api->getData();
             $this->fail('No exception was thrown');
         } catch (Prismic\Exception\RequestFailureException $e) {
             $this->assertContains('example.example', $e->getMessage());


### PR DESCRIPTION
Removes the private property $data from Api so that the payload is always retrieved from the cache, or a fresh request. This fixes an issue where even if you reload the api data during your cache busting event, you'd have to perform this task on every server where $data is held in memory - that's a real pain in the ass.